### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/alkuthari/06bb90a1-1034-43c7-b8dc-1162188b6512/443a59e6-e154-45f7-920d-4c5b6912a4f7/_apis/work/boardbadge/c204348f-2edc-4a9e-8095-208337a78b77)](https://dev.azure.com/alkuthari/06bb90a1-1034-43c7-b8dc-1162188b6512/_boards/board/t/443a59e6-e154-45f7-920d-4c5b6912a4f7/Microsoft.RequirementCategory)
 <p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400"></a></p>
 
 <p align="center">


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#7](https://dev.azure.com/alkuthari/06bb90a1-1034-43c7-b8dc-1162188b6512/_workitems/edit/7). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.